### PR TITLE
将默认配置scale调整为2

### DIFF
--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/AgeratumClientConfig.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/AgeratumClientConfig.java
@@ -36,5 +36,5 @@ public class AgeratumClientConfig {
 
    @Comment("The scaling ratio of the interface")
     @BoundedDiscrete(min = 1, max = 4)
-    public int scale = 1;
+    public int scale = 2;
 }


### PR DESCRIPTION
没办法，看起来更多人的屏幕更适合scale = 2；要是有“自动”选项就好了