### PR TITLE
Fix sidebar scrolling issues and enhance guide interactions

### DIFF
--- a/gradle/scripts/moddevgradle.gradle
+++ b/gradle/scripts/moddevgradle.gradle
@@ -46,3 +46,9 @@ neoForge {
         }
     }
 }
+
+tasks.configureEach {
+    if (name in ['runClient', 'runServer', 'runGameTestServer', 'runData']) {
+        notCompatibleWithConfigurationCache("IntelliJ debugger injects non-cacheable actions into Minecraft run tasks")
+    }
+}

--- a/src/generated/resources/assets/ageratum/lang/en_us.json
+++ b/src/generated/resources/assets/ageratum/lang/en_us.json
@@ -31,5 +31,7 @@
   "key.categories.ageratum": "Ageratum",
   "system.ageratum.share.button": "[CLICK TO OPEN]",
   "system.ageratum.share.tip": "Player %s has shared a guide with you:",
-  "tooltip.ageratum.bind_item_hold": "Hold %s to get more info"
+  "tooltip.ageratum.bind_item_hold": "Hold %s to get more info",
+  "tooltip.ageratum.structure_projection.layer_shortcut": "Press %s / %s to adjust projection layers",
+  "tooltip.ageratum.structure_projection.remove_shortcut": "Press %s to close projection"
 }

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/AgeratumClient.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/AgeratumClient.java
@@ -172,17 +172,37 @@ public class AgeratumClient {
     }
 
     /**
+     * 从侧边栏打开文档，保留当前标签栏滚动和折叠状态。
+     */
+    public static boolean openGuideOnClientPreservingLabelState(ResourceLocation location, List<ResourceLocation> breadCrumbs) {
+        return openGuideOnClientInternal(location, null, breadCrumbs, true);
+    }
+
+    /**
      * 客户端本地打开文档，可选指定锚点；若不存在则返回 false。
      *
      * @param location 文档资源位置
      * @param anchor   目标锚点（可为 null）
      */
     public static boolean openGuideOnClient(ResourceLocation location, @Nullable String anchor, List<ResourceLocation> breadCrumbs) {
+        return openGuideOnClientInternal(location, anchor, breadCrumbs, false);
+    }
+
+    private static boolean openGuideOnClientInternal(
+        ResourceLocation location,
+        @Nullable String anchor,
+        List<ResourceLocation> breadCrumbs,
+        boolean preserveLabelState
+    ) {
         if (isPreviewLocation(location)) {
-            return openPreviewGuideOnClient(location, anchor, breadCrumbs);
+            return openPreviewGuideOnClient(location, anchor, breadCrumbs, preserveLabelState);
         }
 
         Minecraft minecraft = Minecraft.getInstance();
+        GuideScreen currentGuideScreen = null;
+        if (minecraft.screen instanceof GuideScreen guideScreen) {
+            currentGuideScreen = guideScreen;
+        }
         ResourceManager resourceManager = minecraft.getResourceManager();
         if (!GuideDocumentLoader.exists(resourceManager, location)) {
             return false;
@@ -190,7 +210,7 @@ public class AgeratumClient {
 
         int inheritedLabelScrollRows = 0;
         double inheritedLabelScrollRemainder = 0.0d;
-        if (minecraft.screen instanceof GuideScreen currentGuideScreen) {
+        if (currentGuideScreen != null) {
             inheritedLabelScrollRows = currentGuideScreen.getLabelScrollRows();
             inheritedLabelScrollRemainder = currentGuideScreen.getLabelScrollRemainder();
         }
@@ -201,6 +221,9 @@ public class AgeratumClient {
             GuideScreen screen = new GuideScreen(location, cachedDocument.get(), breadCrumbs, false);
             screen.setAnchor(anchor);
             screen.setLabelScrollState(inheritedLabelScrollRows, inheritedLabelScrollRemainder);
+            if (preserveLabelState && currentGuideScreen != null) {
+                screen.setLabelStatePreserved(currentGuideScreen);
+            }
             minecraft.setScreen(screen);
             return true;
         }
@@ -213,6 +236,8 @@ public class AgeratumClient {
             minecraft,
             inheritedLabelScrollRows,
             inheritedLabelScrollRemainder,
+            currentGuideScreen,
+            preserveLabelState,
             content,
             false
         );
@@ -221,9 +246,14 @@ public class AgeratumClient {
     private static boolean openPreviewGuideOnClient(
         ResourceLocation location,
         @Nullable String anchor,
-        List<ResourceLocation> breadCrumbs
+        List<ResourceLocation> breadCrumbs,
+        boolean preserveLabelState
     ) {
         Minecraft minecraft = Minecraft.getInstance();
+        GuideScreen currentGuideScreen = null;
+        if (minecraft.screen instanceof GuideScreen guideScreen) {
+            currentGuideScreen = guideScreen;
+        }
         Path previewFile = resolvePreviewDocumentPath(location);
         if (!Files.isRegularFile(previewFile)) {
             return false;
@@ -231,7 +261,7 @@ public class AgeratumClient {
 
         int inheritedLabelScrollRows = 0;
         double inheritedLabelScrollRemainder = 0.0d;
-        if (minecraft.screen instanceof GuideScreen currentGuideScreen) {
+        if (currentGuideScreen != null) {
             inheritedLabelScrollRows = currentGuideScreen.getLabelScrollRows();
             inheritedLabelScrollRemainder = currentGuideScreen.getLabelScrollRemainder();
         }
@@ -251,6 +281,8 @@ public class AgeratumClient {
             minecraft,
             inheritedLabelScrollRows,
             inheritedLabelScrollRemainder,
+            currentGuideScreen,
+            preserveLabelState,
             content,
             true
         );
@@ -263,6 +295,8 @@ public class AgeratumClient {
         Minecraft minecraft,
         int inheritedLabelScrollRows,
         double inheritedLabelScrollRemainder,
+        @Nullable GuideScreen currentGuideScreen,
+        boolean preserveLabelState,
         String content,
         boolean preview
     ) {
@@ -270,6 +304,9 @@ public class AgeratumClient {
         GuideScreen screen = new GuideScreen(location, parsedDocument, breadCrumbs, preview);
         screen.setAnchor(anchor);
         screen.setLabelScrollState(inheritedLabelScrollRows, inheritedLabelScrollRemainder);
+        if (preserveLabelState && currentGuideScreen != null) {
+            screen.setLabelStatePreserved(currentGuideScreen);
+        }
         minecraft.setScreen(screen);
         return true;
     }

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/command/AgeratumCommand.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/command/AgeratumCommand.java
@@ -137,7 +137,7 @@ public class AgeratumCommand {
         Component message = Component.literal(itemId.toString())
             .withStyle(style -> style.withColor(0xFF66CCFF)
                 .withUnderlined(true)
-                .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, refString))
+                .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, itemId.toString()))
                 .withHoverEvent(new HoverEvent(
                     HoverEvent.Action.SHOW_TEXT,
                     Component.translatable("commands.ageratum.item.id_copy_hint")

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/MDRenderContext.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/MDRenderContext.java
@@ -62,14 +62,22 @@ public record MDRenderContext(
     }
 
     public void addTooltip(ItemStack stack) {
-        this.tooltips.add(new Tooltip(Screen.getTooltipFromItem(Minecraft.getInstance(), stack), stack.getTooltipImage()));
+        this.tooltips.add(new Tooltip(
+            Screen.getTooltipFromItem(Minecraft.getInstance(), stack),
+            stack.getTooltipImage(),
+            stack
+        ));
     }
 
     public void addTooltip(Component text) {
-        this.tooltips.add(new Tooltip(List.of(text), Optional.empty()));
+        this.tooltips.add(new Tooltip(List.of(text), Optional.empty(), ItemStack.EMPTY));
     }
 
-    public record Tooltip(List<Component> tooltipLines, Optional<TooltipComponent> visualTooltipComponent) {
+    public record Tooltip(
+        List<Component> tooltipLines,
+        Optional<TooltipComponent> visualTooltipComponent,
+        ItemStack stack
+    ) {
     }
 
     public void enableScissor(int minX, int minY, int maxX, int maxY) {
@@ -90,14 +98,29 @@ public record MDRenderContext(
 
     public void renderTooltip() {
         for (MDRenderContext.Tooltip tooltip : this.tooltips()) {
-            this.graphics()
-                .renderTooltip(
-                    this.minecraft().font,
-                    tooltip.tooltipLines(),
-                    tooltip.visualTooltipComponent(),
-                    Math.round(this.mouseX()),
-                    Math.round(this.mouseY())
-                );
+            ItemStack stack = tooltip.stack();
+            int mouseX = Math.round(this.mouseX());
+            int mouseY = Math.round(this.mouseY());
+            if (stack.isEmpty()) {
+                this.graphics()
+                    .renderTooltip(
+                        this.minecraft().font,
+                        tooltip.tooltipLines(),
+                        tooltip.visualTooltipComponent(),
+                        mouseX,
+                        mouseY
+                    );
+            } else {
+                this.graphics()
+                    .renderTooltip(
+                        this.minecraft().font,
+                        tooltip.tooltipLines(),
+                        tooltip.visualTooltipComponent(),
+                        stack,
+                        mouseX,
+                        mouseY
+                    );
+            }
         }
     }
 

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/MDRenderContext.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/MDRenderContext.java
@@ -70,7 +70,11 @@ public record MDRenderContext(
     }
 
     public void addTooltip(Component text) {
-        this.tooltips.add(new Tooltip(List.of(text), Optional.empty(), ItemStack.EMPTY));
+        this.addTooltip(List.of(text));
+    }
+
+    public void addTooltip(List<Component> lines) {
+        this.tooltips.add(new Tooltip(lines, Optional.empty(), ItemStack.EMPTY));
     }
 
     public record Tooltip(

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/component/extend/MDBlockComponent.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/component/extend/MDBlockComponent.java
@@ -104,21 +104,17 @@ GuiGraphics graphics = context.graphics();
     }
 
     /**
-     * 渲染方块物品 tooltip，并检查文档绑定添加 W 键提示。
+     * 渲染方块物品 tooltip，并检查文档绑定；W 键提示由 tooltip 事件统一注入。
      */
     private void renderBlockItem(MDRenderContext context, ItemStack stack, int startX, int startY, float mouseX, float mouseY) {
         if (this.isHoverItem(startX, startY, mouseX, mouseY)) {
             context.addTooltip(stack);
-            Minecraft minecraft = context.minecraft();
-            String languageCode = AgeratumClient.getClientLanguageCode(minecraft);
-            GuideDocumentCache.getFirstDocumentByItemStack(stack, languageCode).ifPresentOrElse(
-                doc -> {
-                    this.hoveredDocLink = doc;
-                    context.addTooltip(Component.translatable(
-                        "tooltip.ageratum.bind_item_hold",
-                        Component.keybind("key.ageratum.more_info")
-                    ));
-                },
+            // W 键提示由 BoundItemGuideNavigator 通过 RenderTooltipEvent 注入，这里只记录跳转目标。
+            GuideDocumentCache.getFirstDocumentByItemStack(
+                stack,
+                AgeratumClient.getClientLanguageCode(context.minecraft())
+            ).ifPresentOrElse(
+                doc -> this.hoveredDocLink = doc,
                 () -> this.hoveredDocLink = null
             );
         }

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/component/extend/MDNBTStructureComponent.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/component/extend/MDNBTStructureComponent.java
@@ -178,6 +178,19 @@ public final class MDNBTStructureComponent extends MDComponent {
             AgeratumConstants.GuideScreenUI.Positions.STRUCTURE_BUTTON_WIDTH,
             32
         );
+        if (isHover) {
+            context.addTooltip(List.of(
+                Component.translatable(
+                    "tooltip.ageratum.structure_projection.layer_shortcut",
+                    Component.keybind("key.ageratum.structure_projection.layer_up"),
+                    Component.keybind("key.ageratum.structure_projection.layer_down")
+                ),
+                Component.translatable(
+                    "tooltip.ageratum.structure_projection.remove_shortcut",
+                    Component.keybind("key.ageratum.structure_projection.remove")
+                )
+            ));
+        }
     }
 
     @Override

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/component/extend/MDRecipeComponent.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/component/extend/MDRecipeComponent.java
@@ -13,7 +13,6 @@ import lombok.Getter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Recipe;
@@ -78,22 +77,18 @@ public abstract class MDRecipeComponent extends MDImageComponent {
     }
 
     /**
-     * 渲染配方物品并检查文档绑定，若存在则记录到 {@link #hoveredDocLink}
-     * 并在 tooltip 中显示 W 键跳转提示。
+     * 渲染配方物品并检查文档绑定，若存在则记录到 {@link #hoveredDocLink}。
+     * W 键提示由 tooltip 事件在渲染物品 tooltip 时统一注入。
      */
     protected void renderRecipeItem(MDRenderContext context, ItemStack stack, int startX, int startY, float mouseX, float mouseY) {
         if (this.isHoverItem(startX, startY, mouseX, mouseY)) {
             context.addTooltip(stack);
-            Minecraft minecraft = context.minecraft();
-            String languageCode = AgeratumClient.getClientLanguageCode(minecraft);
-            GuideDocumentCache.getFirstDocumentByItemStack(stack, languageCode).ifPresentOrElse(
-                doc -> {
-                    this.hoveredDocLink = doc;
-                    context.addTooltip(Component.translatable(
-                        "tooltip.ageratum.bind_item_hold",
-                        Component.keybind("key.ageratum.more_info")
-                    ));
-                },
+            // W 键提示由 BoundItemGuideNavigator 通过 RenderTooltipEvent 注入，这里只记录跳转目标。
+            GuideDocumentCache.getFirstDocumentByItemStack(
+                stack,
+                AgeratumClient.getClientLanguageCode(context.minecraft())
+            ).ifPresentOrElse(
+                doc -> this.hoveredDocLink = doc,
                 () -> this.hoveredDocLink = null
             );
         }

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/component/extend/MDRowComponent.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/feat/markdown/component/extend/MDRowComponent.java
@@ -44,8 +44,6 @@ public class MDRowComponent extends MDComponent {
     private final Direction direction;
     private final HorizontalAlign horizontalAlign;
     private final VerticalAlign verticalAlign;
-    /** 水平布局时的统一缩放比（0 表示无需缩放）。 */
-    private float uniformScale;
 
     public MDRowComponent(
         List<MDComponent> contentComponents,
@@ -58,7 +56,6 @@ public class MDRowComponent extends MDComponent {
         this.direction = direction;
         this.horizontalAlign = horizontalAlign;
         this.verticalAlign = verticalAlign;
-        this.uniformScale = 0f;
     }
 
     public static MDComponent parse(MDExtensionContext context) {
@@ -105,83 +102,46 @@ public class MDRowComponent extends MDComponent {
         float mouseX = context.mouseX();
         float mouseY = context.mouseY();
         GuiGraphics guiGraphics = context.graphics();
-
-        // 先以无约束宽度计算各组件完整 preferredWidth
-        int[] preferredWidths = this.calculateUnconstrainedWidths(minecraft);
-        int[] heights = new int[this.contentComponents.size()];
-        int rowHeight = 0;
-        for (int i = 0; i < this.contentComponents.size(); i++) {
-            int h = this.contentComponents.get(i).getHeight(minecraft, preferredWidths[i], Integer.MAX_VALUE);
-            heights[i] = h;
-            rowHeight = Math.max(rowHeight, h);
+        List<MDComponent> children = this.contentComponents;
+        if (children.isEmpty()) {
+            return;
         }
 
-        int totalPreferred = sum(preferredWidths) + SPACING * (this.contentComponents.size() - 1);
-        // 计算统一缩放比：超出可用宽度时等比缩小
-        float scale = totalPreferred > maxX ? (float) maxX / totalPreferred : 1.0f;
-        this.uniformScale = scale;
-
-        // 缩放后的真实宽度
-        int[] widths = new int[this.contentComponents.size()];
-        for (int i = 0; i < this.contentComponents.size(); i++) {
-            widths[i] = Math.max(1, Math.round(preferredWidths[i] * scale));
-        }
-        int totalWidth = sum(widths) + SPACING * (this.contentComponents.size() - 1);
-        int baseX = alignOffset(maxX, totalWidth, this.horizontalAlign);
-
+        // 各组件保持自然尺寸；一行放不下时自动换行。
+        WrappedLayout layout = this.computeWrappedLayout(minecraft, maxX);
         PoseStack pose = guiGraphics.pose();
         pose.pushPose();
-        pose.translate(baseX, 0, 0);
 
-        int currentX = 0;
-        for (int i = 0; i < this.contentComponents.size(); i++) {
-            MDComponent component = this.contentComponents.get(i);
-            int preferredW = preferredWidths[i];
-            int componentHeight = heights[i];
-            int yOffset = alignOffset(rowHeight, componentHeight, this.verticalAlign);
-            int scaledYOffset = scale < 1.0f ? Math.round(yOffset * scale) : yOffset;
-
+        int lineTop = 0;
+        for (RowLayout line : layout.lines()) {
+            int baseX = alignOffset(maxX, line.lineWidth(), this.horizontalAlign);
             pose.pushPose();
-            if (scale < 1.0f) {
-                pose.translate(0, scaledYOffset, 0);
-                pose.scale(scale, scale, 1.0f);
-                int childMaxY = maxY <= 0 ? maxY : (int) Math.max(1, (maxY - scaledYOffset) / scale);
+            pose.translate(baseX, lineTop, 0);
+            int currentX = 0;
+            for (PlacedChild placed : line.children()) {
+                MDComponent component = children.get(placed.index());
+                int yOffset = alignOffset(line.lineHeight(), placed.height(), this.verticalAlign);
                 int childX = baseX + currentX;
-                float childMouseX = (mouseX - childX) / scale;
-                float childMouseY = (mouseY - scaledYOffset) / scale;
+                int childY = lineTop + yOffset;
+                int childMaxY = maxY <= 0 ? maxY : Math.max(0, maxY - childY);
+                pose.pushPose();
+                pose.translate(currentX, yOffset, 0);
                 component.render(
                     context.child(
-                        preferredW,
-                        childMaxY,
-                        childMouseX,
-                        childMouseY,
-                        Math.round(context.offsetX() + childX / scale),
-                        Math.round(context.offsetY() + scaledYOffset / scale),
-                        context.scale() * scale
-                    )
-                );
-            } else {
-                pose.translate(0, yOffset, 0);
-                int childMaxY = maxY <= 0 ? maxY : Math.max(0, maxY - yOffset);
-                int childX = baseX + currentX;
-                component.render(
-                    context.child(
-                        preferredW,
+                        placed.width(),
                         childMaxY,
                         mouseX - childX,
-                        mouseY - yOffset,
+                        mouseY - childY,
                         context.offsetX() + childX,
-                        context.offsetY() + yOffset,
+                        context.offsetY() + childY,
                         context.scale()
                     )
                 );
+                pose.popPose();
+                currentX += placed.width() + SPACING;
             }
             pose.popPose();
-
-            if (i < this.contentComponents.size() - 1) {
-                currentX += widths[i] + SPACING;
-                pose.translate(widths[i] + SPACING, 0, 0);
-            }
+            lineTop += line.lineHeight() + SPACING;
         }
 
         pose.popPose();
@@ -249,17 +209,15 @@ public class MDRowComponent extends MDComponent {
             return height;
         }
 
-        int[] preferredWidths = this.calculateUnconstrainedWidths(minecraft);
-        int totalPreferred = sum(preferredWidths) + SPACING * (this.contentComponents.size() - 1);
-        float scale = totalPreferred > maxX ? (float) maxX / totalPreferred : 1.0f;
-
-        int maxHeight = 0;
-        for (int i = 0; i < this.contentComponents.size(); i++) {
-            MDComponent component = this.contentComponents.get(i);
-            int height = component.getHeight(minecraft, preferredWidths[i], maxY);
-            maxHeight = Math.max(maxHeight, height);
+        WrappedLayout layout = this.computeWrappedLayout(minecraft, maxX);
+        int height = 0;
+        for (int i = 0; i < layout.lines().size(); i++) {
+            height += layout.lines().get(i).lineHeight();
+            if (i < layout.lines().size() - 1) {
+                height += SPACING;
+            }
         }
-        return scale < 1.0f ? Math.max(1, Math.round(maxHeight * scale)) : maxHeight;
+        return Math.max(0, height);
     }
 
     private static int resolveVerticalChildWidth(MDComponent component, Minecraft minecraft, int maxX) {
@@ -301,6 +259,36 @@ public class MDRowComponent extends MDComponent {
             widths[i] = preferred > 0 ? preferred : 1;
         }
         return widths;
+    }
+
+    /**
+     * 将水平子组件按自然尺寸分组为多行：一行放不下时换行。
+     */
+    private WrappedLayout computeWrappedLayout(Minecraft minecraft, int maxX) {
+        int[] preferredWidths = this.calculateUnconstrainedWidths(minecraft);
+        List<RowLayout> rows = new ArrayList<>();
+        List<PlacedChild> currentChildren = new ArrayList<>();
+        int currentWidth = 0;
+        int currentHeight = 0;
+        for (int i = 0; i < preferredWidths.length; i++) {
+            int width = preferredWidths[i];
+            int height = this.contentComponents.get(i).getHeight(minecraft, width, Integer.MAX_VALUE);
+            int addWidth = currentChildren.isEmpty() ? width : currentWidth + SPACING + width;
+            if (!currentChildren.isEmpty() && addWidth > maxX) {
+                rows.add(new RowLayout(currentChildren, currentWidth, currentHeight));
+                currentChildren = new ArrayList<>();
+                currentWidth = 0;
+                currentHeight = 0;
+                addWidth = width;
+            }
+            currentChildren.add(new PlacedChild(i, width, height));
+            currentWidth = addWidth;
+            currentHeight = Math.max(currentHeight, height);
+        }
+        if (!currentChildren.isEmpty()) {
+            rows.add(new RowLayout(currentChildren, currentWidth, currentHeight));
+        }
+        return new WrappedLayout(rows);
     }
 
     @Override
@@ -441,6 +429,24 @@ public class MDRowComponent extends MDComponent {
     private record ChildHit(MDComponent component, int x, int y, int width, int height) {
     }
 
+    /**
+     * 换行后的完整水平布局。
+     */
+    private record WrappedLayout(List<RowLayout> lines) {
+    }
+
+    /**
+     * 一行内的子组件及其行宽、行高。
+     */
+    private record RowLayout(List<PlacedChild> children, int lineWidth, int lineHeight) {
+    }
+
+    /**
+     * 已放置的子组件索引与自然尺寸（不随行内拥挤缩放）。
+     */
+    private record PlacedChild(int index, int width, int height) {
+    }
+
     private @Nullable ChildHit hitTest(Minecraft minecraft, double mouseX, double mouseY, int maxX) {
         if (mouseX < 0 || mouseY < 0 || maxX <= 0 || this.contentComponents.isEmpty()) {
             return null;
@@ -452,47 +458,28 @@ public class MDRowComponent extends MDComponent {
     }
 
     private @Nullable ChildHit hitTestHorizontal(Minecraft minecraft, double mouseX, double mouseY, int maxX) {
-        int[] preferredWidths = this.calculateUnconstrainedWidths(minecraft);
-
-        int[] heights = new int[this.contentComponents.size()];
-        int rowHeight = 0;
-        for (int i = 0; i < this.contentComponents.size(); i++) {
-            int h = this.contentComponents.get(i).getHeight(minecraft, preferredWidths[i], Integer.MAX_VALUE);
-            heights[i] = h;
-            rowHeight = Math.max(rowHeight, h);
-        }
-
-        int totalPreferred = sum(preferredWidths) + SPACING * (this.contentComponents.size() - 1);
-        float scale = totalPreferred > maxX ? (float) maxX / totalPreferred : 1.0f;
-
-        int[] widths = new int[this.contentComponents.size()];
-        for (int i = 0; i < this.contentComponents.size(); i++) {
-            widths[i] = Math.max(1, Math.round(preferredWidths[i] * scale));
-        }
-
-        int totalWidth = sum(widths) + SPACING * (this.contentComponents.size() - 1);
-        int baseX = alignOffset(maxX, totalWidth, this.horizontalAlign);
-
-        int currentX = 0;
-        for (int i = 0; i < this.contentComponents.size(); i++) {
-            MDComponent component = this.contentComponents.get(i);
-            int width = widths[i];
-            int height = heights[i];
-            int yOffset = alignOffset(rowHeight, height, this.verticalAlign);
-            int scaledHeight = scale < 1.0f ? Math.max(1, Math.round(height * scale)) : height;
-            int scaledYOffset = scale < 1.0f ? Math.round(yOffset * scale) : yOffset;
-            int x = baseX + currentX;
-
-            if (mouseX >= x && mouseX < x + width) {
-                if (mouseY < scaledYOffset || mouseY >= scaledYOffset + scaledHeight) {
-                    return null;
+        WrappedLayout layout = this.computeWrappedLayout(minecraft, maxX);
+        int lineTop = 0;
+        for (RowLayout line : layout.lines()) {
+            int baseX = alignOffset(maxX, line.lineWidth(), this.horizontalAlign);
+            int currentX = 0;
+            for (PlacedChild placed : line.children()) {
+                int yOffset = alignOffset(line.lineHeight(), placed.height(), this.verticalAlign);
+                int x = baseX + currentX;
+                int y = lineTop + yOffset;
+                if (mouseX >= x && mouseX < x + placed.width() && mouseY >= y && mouseY < y + placed.height()) {
+                    return new ChildHit(
+                        this.contentComponents.get(placed.index()),
+                        x,
+                        y,
+                        placed.width(),
+                        placed.height()
+                    );
                 }
-                return new ChildHit(component, x, scaledYOffset, width, scaledHeight);
+                currentX += placed.width() + SPACING;
             }
-
-            currentX += width + SPACING;
+            lineTop += line.lineHeight() + SPACING;
         }
-
         return null;
     }
 

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/gui/GuideScreen.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/gui/GuideScreen.java
@@ -1642,14 +1642,12 @@ public class GuideScreen extends Screen {
     }
 
     private boolean handleLabelEntryClick(LabelEntry entry, int entryIndexInFull) {
-        // Shift+左键 → 切换父标签折叠状态
-        if (Screen.hasShiftDown() && entry.level == 1 && this.labelGroupHasChildren(entryIndexInFull)) {
+        // 左键点击大章时切换展开/收起，并继续打开其 index 内容
+        if (entry.level == 1 && this.labelGroupHasChildren(entryIndexInFull)) {
             this.toggleLabelGroup(entryIndexInFull);
-            return true;
         }
-        // 普通左键 → 跳转页面
         if (!entry.clickable || entry.location == null) {
-            return false;
+            return entry.level == 1 && this.labelGroupHasChildren(entryIndexInFull);
         }
         List<ResourceLocation> breadCrumbs = this.breadCrumbs;
         if (AgeratumClient.CONFIG.breadCrumbsHasLabel && !entry.location.equals(this.documentLocation)) {
@@ -2375,7 +2373,7 @@ public class GuideScreen extends Screen {
     /**
      * 渲染侧边标签的 tooltip。
      *
-     * <p>对父标签显示完整名称和 Shift+左键 折叠/展开提示。</p>
+     * <p>对父标签显示完整名称和左键折叠/展开提示。</p>
      */
     private void renderLabelTooltips(GuiGraphics guiGraphics, int mouseX, int mouseY) {
         int pinnedParentIndex = this.findPinnedParentIndex();
@@ -2434,7 +2432,11 @@ public class GuideScreen extends Screen {
         // 父标签且拥有子标签时，显示折叠提示
         if (entry.level == 1 && this.labelGroupHasChildren(entryIndexInFull)) {
             boolean collapsed = this.collapsedLabelGroups.contains(entryIndexInFull);
-            lines.add(Component.literal(collapsed ? "Shift+左键 展开" : "Shift+左键 收起"));
+            if (entry.clickable && entry.location != null) {
+                lines.add(Component.literal(collapsed ? "左键 展开并打开" : "左键 收起并打开"));
+            } else {
+                lines.add(Component.literal(collapsed ? "左键 展开" : "左键 收起"));
+            }
         }
         guiGraphics.renderTooltip(
             this.font,
@@ -2455,17 +2457,16 @@ public class GuideScreen extends Screen {
         if (this.visibleLabelIndices.isEmpty()) {
             return -1;
         }
-        int firstVisibleIndex = this.visibleLabelIndices.get(
-            Mth.clamp(this.labelScrollRows, 0, this.visibleLabelIndices.size() - 1)
-        );
+        int clampedScrollRows = Mth.clamp(this.labelScrollRows, 0, this.visibleLabelIndices.size() - 1);
+        int firstVisibleIndex = this.visibleLabelIndices.get(clampedScrollRows);
         LabelEntry firstVisibleEntry = this.labelEntries.get(firstVisibleIndex);
         if (firstVisibleEntry.level == 2) {
             return this.findParentGroupIndex(firstVisibleIndex);
         }
-        if (this.labelScrollRows <= 0) {
+        if (clampedScrollRows <= 0) {
             return -1;
         }
-        int previousVisibleIndex = this.visibleLabelIndices.get(this.labelScrollRows - 1);
+        int previousVisibleIndex = this.visibleLabelIndices.get(clampedScrollRows - 1);
         LabelEntry previousVisibleEntry = this.labelEntries.get(previousVisibleIndex);
         if (previousVisibleEntry.level == 2) {
             return this.findParentGroupIndex(previousVisibleIndex);
@@ -2626,10 +2627,8 @@ public class GuideScreen extends Screen {
         }
         for (int i = groupIndex + 1; i < this.labelEntries.size(); i++) {
             LabelEntry entry = this.labelEntries.get(i);
-            if (entry.level == 1) {
-                return false; // 遇到下一个 level==1，说明没有子标签
-            }
-            return true; // 找到 level==2
+            return entry.level != 1; // 遇到下一个 level==1，说明没有子标签
+// 找到 level==2
         }
         return false;
     }

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/gui/GuideScreen.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/gui/GuideScreen.java
@@ -16,6 +16,7 @@ import dev.anvilcraft.resource.ageratum.client.feat.markdown.component.MDHeaderC
 import dev.anvilcraft.resource.ageratum.client.util.RelativePathResolver;
 import dev.anvilcraft.resource.ageratum.network.ShareGuidePayload;
 import lombok.Getter;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
@@ -509,15 +510,26 @@ public class GuideScreen extends Screen {
             return super.mouseScrolled(mouseX, mouseY, scrollX, scrollY);
         }
 
+        // Ctrl/Alt/Shift 加速内容区翻滚（3倍速度）
+        double acceleratedScrollY = scrollY;
+        if (Screen.hasControlDown() || Screen.hasAltDown() || Screen.hasShiftDown()) {
+            acceleratedScrollY *= 3.0;
+        }
         if (this.minecraft != null) {
             ComponentMouseHit hit = this.getComponentHitAtContentPosition(mouseX, mouseY);
-            if (hit != null && hit.component().mouseScrolled(this.minecraft, hit.mouseX(), hit.mouseY(), scrollY, this.getContentWidth())) {
+            if (hit != null && hit.component().mouseScrolled(
+                this.minecraft,
+                hit.mouseX(),
+                hit.mouseY(),
+                acceleratedScrollY,
+                this.getContentWidth()
+            )) {
                 return true;
             }
         }
 
         // scrollY 为正表示向上滚动，故取负以减小 contentScroll（内容上移）
-        this.scrollBy((float) -scrollY * SCROLL_STEP);
+        this.scrollBy((float) -acceleratedScrollY * SCROLL_STEP);
         return true;
     }
 
@@ -2429,13 +2441,15 @@ public class GuideScreen extends Screen {
         List<Component> lines = new ArrayList<>();
         // 第一行：完整名称
         lines.add(Component.literal(entry.title.getString()));
+        // 滚动加速提示
+        lines.add(Component.literal("按住alt/shift/ctrl加速滑动").withStyle(ChatFormatting.GRAY));
         // 父标签且拥有子标签时，显示折叠提示
         if (entry.level == 1 && this.labelGroupHasChildren(entryIndexInFull)) {
             boolean collapsed = this.collapsedLabelGroups.contains(entryIndexInFull);
             if (entry.clickable && entry.location != null) {
-                lines.add(Component.literal(collapsed ? "左键 展开并打开" : "左键 收起并打开"));
+                lines.add(Component.literal(collapsed ? "左键 展开并打开" : "左键 收起并打开").withStyle(ChatFormatting.GRAY));
             } else {
-                lines.add(Component.literal(collapsed ? "左键 展开" : "左键 收起"));
+                lines.add(Component.literal(collapsed ? "左键 展开" : "左键 收起").withStyle(ChatFormatting.GRAY));
             }
         }
         guiGraphics.renderTooltip(
@@ -2628,7 +2642,6 @@ public class GuideScreen extends Screen {
         for (int i = groupIndex + 1; i < this.labelEntries.size(); i++) {
             LabelEntry entry = this.labelEntries.get(i);
             return entry.level != 1; // 遇到下一个 level==1，说明没有子标签
-// 找到 level==2
         }
         return false;
     }

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/gui/GuideScreen.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/gui/GuideScreen.java
@@ -2448,44 +2448,29 @@ public class GuideScreen extends Screen {
     /**
      * 查找需要固定在顶部的父标签索引。
      *
-     * <p>当当前页面是 level==2 的子标签，且其父标签已滚出可视范围时，
-     * 返回父标签在 labelEntries 中的索引；否则返回 -1。</p>
+     * <p>第 1 行固定为“首个可见标签”所属的大章；当首行已经滚到章节标题时，
+     * 沿用上一行所属大章，避免滚动一格后顶部大章提前切换。</p>
      */
     private int findPinnedParentIndex() {
-        String currentFile = this.getCurrentFileArgument();
-        int activeIndex = -1;
-        for (int i = 0; i < this.labelEntries.size(); i++) {
-            LabelEntry entry = this.labelEntries.get(i);
-            if (entry.fileArgument != null && entry.fileArgument.equals(currentFile)) {
-                activeIndex = i;
-                break;
-            }
-        }
-        if (activeIndex < 0) {
+        if (this.visibleLabelIndices.isEmpty()) {
             return -1;
         }
-        LabelEntry activeEntry = this.labelEntries.get(activeIndex);
-        if (activeEntry.level != 2) {
+        int firstVisibleIndex = this.visibleLabelIndices.get(
+            Mth.clamp(this.labelScrollRows, 0, this.visibleLabelIndices.size() - 1)
+        );
+        LabelEntry firstVisibleEntry = this.labelEntries.get(firstVisibleIndex);
+        if (firstVisibleEntry.level == 2) {
+            return this.findParentGroupIndex(firstVisibleIndex);
+        }
+        if (this.labelScrollRows <= 0) {
             return -1;
         }
-        int parentIndex = -1;
-        for (int i = activeIndex - 1; i >= 0; i--) {
-            if (this.labelEntries.get(i).level == 1) {
-                parentIndex = i;
-                break;
-            }
+        int previousVisibleIndex = this.visibleLabelIndices.get(this.labelScrollRows - 1);
+        LabelEntry previousVisibleEntry = this.labelEntries.get(previousVisibleIndex);
+        if (previousVisibleEntry.level == 2) {
+            return this.findParentGroupIndex(previousVisibleIndex);
         }
-        if (parentIndex < 0) {
-            return -1;
-        }
-        if (this.visibleLabelIndices.contains(parentIndex)) {
-            int visiblePos = this.visibleLabelIndices.indexOf(parentIndex);
-            if (visiblePos >= this.labelScrollRows
-                && visiblePos < this.labelScrollRows + this.getLabelVisibleRows()) {
-                return -1;
-            }
-        }
-        return parentIndex;
+        return previousVisibleEntry.level == 1 ? previousVisibleIndex : -1;
     }
 
     /**

--- a/src/main/java/dev/anvilcraft/resource/ageratum/client/gui/GuideScreen.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/client/gui/GuideScreen.java
@@ -170,6 +170,14 @@ public class GuideScreen extends Screen {
      */
     protected final Set<Integer> collapsedLabelGroups = new HashSet<>();
     /**
+     * 从侧边栏打开页面时，是否保留当前标签栏的滚动与折叠状态。
+     */
+    protected boolean preserveLabelState;
+    /**
+     * 从侧边栏打开页面时继承的父标签折叠状态。
+     */
+    protected Set<Integer> inheritedCollapsedLabelGroups = Set.of();
+    /**
      * 当前可见标签在 labelEntries 中的索引列表（受折叠状态影响）。
      */
     protected List<Integer> visibleLabelIndices = List.of();
@@ -315,6 +323,14 @@ public class GuideScreen extends Screen {
     }
 
     /**
+     * 保留来源界面的侧边标签栏状态，用于侧边栏点击跳转。
+     */
+    public void setLabelStatePreserved(GuideScreen currentGuideScreen) {
+        this.preserveLabelState = true;
+        this.inheritedCollapsedLabelGroups = Set.copyOf(currentGuideScreen.collapsedLabelGroups);
+    }
+
+    /**
      * 界面初始化（每次打开或窗口大小改变时调用）。
      *
      * <p>重新计算 {@link #leftPos} 与 {@link #topPos} 使界面居中，
@@ -367,7 +383,7 @@ public class GuideScreen extends Screen {
         this.ensureBookmarksLoaded();
         // 防止窗口缩小后滚动量超出边界
         this.contentScroll = Mth.clamp(this.contentScroll, 0.0f, this.maxContentScroll);
-        this.labelScrollRows = Mth.clamp(this.labelScrollRows, 0, this.maxLabelScrollRows);
+        this.labelScrollRows = Mth.clamp(this.labelScrollRows, 0, this.getMaxLabelScrollRows());
         this.refreshBookmarkScrollState();
     }
 
@@ -802,7 +818,7 @@ public class GuideScreen extends Screen {
         // ── 检查是否需要固定父标签 ──
         int pinnedParentIndex = this.findPinnedParentIndex();
         int pinnedRowCount = pinnedParentIndex >= 0 ? 1 : 0;
-        int start = this.labelScrollRows;
+        int start = this.getLabelViewportStart(pinnedRowCount);
         int end = Math.min(this.getVisibleLabelCount(), start + this.getLabelVisibleRows() - pinnedRowCount);
         String currentFile = this.getCurrentFileArgument();
         PoseStack pose = guiGraphics.pose();
@@ -968,7 +984,7 @@ public class GuideScreen extends Screen {
     }
 
     private void renderLabelScrollHint(GuiGraphics guiGraphics) {
-        if (this.maxLabelScrollRows <= 0) {
+        if (this.getMaxLabelScrollRows() <= 0) {
             return;
         }
 
@@ -996,7 +1012,7 @@ public class GuideScreen extends Screen {
             );
             guiGraphics.setColor(1.0f, 1.0f, 1.0f, 1.0f);
         }
-        int rowsToBottom = this.maxLabelScrollRows - this.labelScrollRows;
+        int rowsToBottom = this.getMaxLabelScrollRows() - this.labelScrollRows;
         if (rowsToBottom > 0) {
             float alpha = this.computeArrowAlpha(rowsToBottom);
             guiGraphics.setColor(1.0f, 1.0f, 1.0f, alpha);
@@ -1371,7 +1387,7 @@ public class GuideScreen extends Screen {
     }
 
     private void scrollLabelsBy(int deltaRows) {
-        this.labelScrollRows = Mth.clamp(this.labelScrollRows + deltaRows, 0, this.maxLabelScrollRows);
+        this.labelScrollRows = Mth.clamp(this.labelScrollRows + deltaRows, 0, this.getMaxLabelScrollRows());
     }
 
     private void rebuildLabelEntries(ResourceManager resourceManager) {
@@ -1416,11 +1432,18 @@ public class GuideScreen extends Screen {
         }
 
         this.labelEntries = List.copyOf(finalEntries);
-        // 默认折叠所有父标签组
-        this.collapseAllLabelGroups();
+        if (this.preserveLabelState) {
+            this.applyLabelGroupState(this.inheritedCollapsedLabelGroups);
+        } else {
+            // 默认折叠所有父标签组
+            this.collapseAllLabelGroups();
+        }
         this.maxLabelScrollRows = Math.max(0, this.getVisibleLabelCount() - this.getLabelVisibleRows());
-        this.labelScrollRows = Mth.clamp(this.labelScrollRows, 0, this.maxLabelScrollRows);
-        this.scrollLabelToCurrentDocument();
+        this.labelScrollRows = Mth.clamp(this.labelScrollRows, 0, this.getMaxLabelScrollRows());
+        if (!this.preserveLabelState) {
+            this.scrollLabelToCurrentDocument();
+        }
+        this.maxLabelScrollRows = this.getMaxLabelScrollRows();
     }
 
     private void rebuildPreviewLabelEntries() {
@@ -1459,11 +1482,18 @@ public class GuideScreen extends Screen {
         }
 
         this.labelEntries = List.copyOf(finalEntries);
-        // 默认折叠所有父标签组
-        this.collapseAllLabelGroups();
+        if (this.preserveLabelState) {
+            this.applyLabelGroupState(this.inheritedCollapsedLabelGroups);
+        } else {
+            // 默认折叠所有父标签组
+            this.collapseAllLabelGroups();
+        }
         this.maxLabelScrollRows = Math.max(0, this.getVisibleLabelCount() - this.getLabelVisibleRows());
-        this.labelScrollRows = Mth.clamp(this.labelScrollRows, 0, this.maxLabelScrollRows);
-        this.scrollLabelToCurrentDocument();
+        this.labelScrollRows = Mth.clamp(this.labelScrollRows, 0, this.getMaxLabelScrollRows());
+        if (!this.preserveLabelState) {
+            this.scrollLabelToCurrentDocument();
+        }
+        this.maxLabelScrollRows = this.getMaxLabelScrollRows();
     }
 
     private void insertPreviewDocument(PreviewDirectoryNode root, Path previewRoot, Path absolutePath) {
@@ -1611,6 +1641,25 @@ public class GuideScreen extends Screen {
         }
     }
 
+    private boolean handleLabelEntryClick(LabelEntry entry, int entryIndexInFull) {
+        // Shift+左键 → 切换父标签折叠状态
+        if (Screen.hasShiftDown() && entry.level == 1 && this.labelGroupHasChildren(entryIndexInFull)) {
+            this.toggleLabelGroup(entryIndexInFull);
+            return true;
+        }
+        // 普通左键 → 跳转页面
+        if (!entry.clickable || entry.location == null) {
+            return false;
+        }
+        List<ResourceLocation> breadCrumbs = this.breadCrumbs;
+        if (AgeratumClient.CONFIG.breadCrumbsHasLabel && !entry.location.equals(this.documentLocation)) {
+            breadCrumbs = new ArrayList<>(this.breadCrumbs);
+            breadCrumbs.add(this.documentLocation);
+            breadCrumbs = List.copyOf(breadCrumbs);
+        }
+        return AgeratumClient.openGuideOnClientPreservingLabelState(entry.location, breadCrumbs);
+    }
+
     private boolean tryOpenLabelAt(double mouseX, double mouseY) {
         if (this.minecraft == null) {
             return false;
@@ -1618,31 +1667,31 @@ public class GuideScreen extends Screen {
         int relMouseX = (int) Math.floor(mouseX - this.leftPos);
         if (relMouseX >= this.getContentStartX()) return false;
         int relMouseY = (int) Math.floor(mouseY - this.topPos);
-        int start = this.labelScrollRows;
-        int end = Math.min(this.getVisibleLabelCount(), start + this.getLabelVisibleRows());
+        int pinnedParentIndex = this.findPinnedParentIndex();
+        int pinnedRowCount = pinnedParentIndex >= 0 ? 1 : 0;
+        int start = this.getLabelViewportStart(pinnedRowCount);
+        int end = Math.min(this.getVisibleLabelCount(), start + this.getLabelVisibleRows() - pinnedRowCount);
+
+        // 先检查固定父标签，它占用第 0 行
+        if (pinnedParentIndex >= 0) {
+            int originX = this.getLabelBaseX();
+            int originY = this.getLabelStartY();
+            if (this.mouseInRange(originX, originY, this.labelWidth, this.labelHeight, relMouseX, relMouseY)) {
+                return this.handleLabelEntryClick(this.labelEntries.get(pinnedParentIndex), pinnedParentIndex);
+            }
+        }
+
         for (int index = start; index < end; index++) {
-            int row = index - start;
+            int row = (index - start) + pinnedRowCount;
             int entryIndexInFull = this.visibleLabelIndices.get(index);
+            if (entryIndexInFull == pinnedParentIndex) {
+                continue;
+            }
             LabelEntry entry = this.labelEntries.get(entryIndexInFull);
             int originX = this.getLabelBaseX() + (entry.level == 2 ? LABEL_LEVEL2_INDENT : 0);
             int originY = this.getLabelStartY() + row * this.getLabelRowOffset();
             if (this.mouseInRange(originX, originY, this.labelWidth, this.labelHeight, relMouseX, relMouseY)) {
-                // Shift+左键 → 切换父标签折叠状态
-                if (Screen.hasShiftDown() && entry.level == 1 && this.labelGroupHasChildren(entryIndexInFull)) {
-                    this.toggleLabelGroup(entryIndexInFull);
-                    return true;
-                }
-                // 普通左键 → 跳转页面
-                if (!entry.clickable || entry.location == null) {
-                    return false;
-                }
-                List<ResourceLocation> breadCrumbs = this.breadCrumbs;
-                if (AgeratumClient.CONFIG.breadCrumbsHasLabel && !entry.location.equals(this.documentLocation)) {
-                    breadCrumbs = new ArrayList<>(this.breadCrumbs);
-                    breadCrumbs.add(this.documentLocation);
-                    breadCrumbs = List.copyOf(breadCrumbs);
-                }
-                return AgeratumClient.openGuideOnClient(entry.location, breadCrumbs);
+                return this.handleLabelEntryClick(entry, entryIndexInFull);
             }
         }
         return false;
@@ -1673,7 +1722,39 @@ public class GuideScreen extends Screen {
         // 滚动使当前标签可见（尽量放在可视区域中间偏上位置）
         int visibleRows = this.getLabelVisibleRows();
         int targetScroll = Math.max(0, visibleIndex - visibleRows / 3);
-        this.labelScrollRows = Mth.clamp(targetScroll, 0, this.maxLabelScrollRows);
+        this.labelScrollRows = Mth.clamp(targetScroll, 0, this.getMaxLabelScrollRows());
+        this.ensureCurrentDocumentVisible();
+    }
+
+    /**
+     * 在当前文档仍可见时，将侧边栏滚动位置微调到当前标签可见。
+     *
+     * <p>仅在展开/收拢导致可见列表长度或位置变化时调整，不改变用户手动滚动后的位置。</p>
+     */
+    private void ensureCurrentDocumentVisible() {
+        int fullIndex = this.findCurrentDocumentLabelIndex();
+        if (fullIndex < 0) {
+            return;
+        }
+        int visibleIndex = this.visibleLabelIndices.indexOf(fullIndex);
+        if (visibleIndex < 0) {
+            return;
+        }
+        for (int attempt = 0; attempt < 3; attempt++) {
+            int oldScroll = this.labelScrollRows;
+            int maxScroll = this.getMaxLabelScrollRows();
+            this.labelScrollRows = Mth.clamp(this.labelScrollRows, 0, maxScroll);
+            int pinnedRowCount = this.findPinnedParentIndex() >= 0 ? 1 : 0;
+            int regularRows = Math.max(1, this.getLabelVisibleRows() - pinnedRowCount);
+            if (visibleIndex < this.labelScrollRows) {
+                this.labelScrollRows = Mth.clamp(visibleIndex, 0, maxScroll);
+            } else if (visibleIndex >= this.labelScrollRows + regularRows) {
+                this.labelScrollRows = Mth.clamp(visibleIndex - (regularRows - 1), 0, maxScroll);
+            }
+            if (this.labelScrollRows == oldScroll) {
+                break;
+            }
+        }
     }
 
     /**
@@ -2117,6 +2198,34 @@ public class GuideScreen extends Screen {
         return this.labelHeight + this.getLabelRowSpacing();
     }
 
+    /**
+     * 计算侧边标签实际渲染时的起始可见索引。
+     *
+     * <p>固定父标签会占用一行，因此需要额外考虑该行对可视容量的影响，
+     * 否则“固定父标签 + 普通滚动”会在末尾丢掉最后一个标签。</p>
+     */
+    private int getLabelViewportStart(int pinnedRowCount) {
+        if (pinnedRowCount <= 0) {
+            return this.labelScrollRows;
+        }
+        int visibleRows = this.getLabelVisibleRows();
+        int regularRows = Math.max(1, visibleRows - pinnedRowCount);
+        int maxStart = Math.max(0, this.getVisibleLabelCount() - regularRows);
+        return Mth.clamp(this.labelScrollRows, 0, maxStart);
+    }
+
+    /**
+     * 计算侧边标签可滚动范围，固定父标签存在时允许多滚动一行。
+     */
+    private int getMaxLabelScrollRows() {
+        int base = Math.max(0, this.getVisibleLabelCount() - this.getLabelVisibleRows());
+        if (this.findPinnedParentIndex() < 0) {
+            return base;
+        }
+        int regularRows = Math.max(1, this.getLabelVisibleRows() - 1);
+        return Math.max(base, Math.max(0, this.getVisibleLabelCount() - regularRows));
+    }
+
     public int getContentWidth() {
         return this.imageWidth - 2 * this.getContentStartX();
     }
@@ -2269,10 +2378,10 @@ public class GuideScreen extends Screen {
      * <p>对父标签显示完整名称和 Shift+左键 折叠/展开提示。</p>
      */
     private void renderLabelTooltips(GuiGraphics guiGraphics, int mouseX, int mouseY) {
-        int start = this.labelScrollRows;
-        int end = Math.min(this.getVisibleLabelCount(), start + this.getLabelVisibleRows());
         int pinnedParentIndex = this.findPinnedParentIndex();
         int pinnedRowCount = pinnedParentIndex >= 0 ? 1 : 0;
+        int start = this.getLabelViewportStart(pinnedRowCount);
+        int end = Math.min(this.getVisibleLabelCount(), start + this.getLabelVisibleRows() - pinnedRowCount);
         String currentFile = this.getCurrentFileArgument();
 
         // 先检查固定父标签
@@ -2467,6 +2576,19 @@ public class GuideScreen extends Screen {
     }
 
     /**
+     * 根据来源界面继承的折叠状态重建父标签组。
+     */
+    private void applyLabelGroupState(Set<Integer> inheritedState) {
+        this.collapsedLabelGroups.clear();
+        for (int i = 0; i < this.labelEntries.size(); i++) {
+            if (this.labelEntries.get(i).level == 1 && inheritedState.contains(i)) {
+                this.collapsedLabelGroups.add(i);
+            }
+        }
+        this.rebuildVisibleLabelIndices();
+    }
+
+    /**
      * 切换指定父标签组的折叠状态。
      */
     private void toggleLabelGroup(int groupIndex) {
@@ -2477,9 +2599,9 @@ public class GuideScreen extends Screen {
         }
         this.rebuildVisibleLabelIndices();
         // 折叠/展开后重新约束滚动范围
-        int visibleRows = this.getLabelVisibleRows();
-        this.maxLabelScrollRows = Math.max(0, this.visibleLabelIndices.size() - visibleRows);
-        this.labelScrollRows = Mth.clamp(this.labelScrollRows, 0, this.maxLabelScrollRows);
+        this.labelScrollRows = Mth.clamp(this.labelScrollRows, 0, this.getMaxLabelScrollRows());
+        this.ensureCurrentDocumentVisible();
+        this.maxLabelScrollRows = this.getMaxLabelScrollRows();
     }
 
     /**

--- a/src/main/java/dev/anvilcraft/resource/ageratum/data/AgeratumLanguageProvider.java
+++ b/src/main/java/dev/anvilcraft/resource/ageratum/data/AgeratumLanguageProvider.java
@@ -22,6 +22,8 @@ public class AgeratumLanguageProvider extends LanguageProvider {
         this.add("system.ageratum.share.tip", "Player %s has shared a guide with you:");
         this.add("system.ageratum.share.button", "[CLICK TO OPEN]");
         this.add("tooltip.ageratum.bind_item_hold", "Hold %s to get more info");
+        this.add("tooltip.ageratum.structure_projection.layer_shortcut", "Press %s / %s to adjust projection layers");
+        this.add("tooltip.ageratum.structure_projection.remove_shortcut", "Press %s to close projection");
         this.add("key.ageratum.more_info", "Get More Info");
         this.add("key.ageratum.structure_projection.layer_up", "Increase Projection Layers");
         this.add("key.ageratum.structure_projection.layer_down", "Decrease Projection Layers");

--- a/src/main/resources/assets/ageratum/lang/zh_cn.json
+++ b/src/main/resources/assets/ageratum/lang/zh_cn.json
@@ -31,5 +31,7 @@
   "key.categories.ageratum": "藿香",
   "system.ageratum.share.button": "[点击打开]",
   "system.ageratum.share.tip": "玩家 %s 向您分享了一份指南：",
-  "tooltip.ageratum.bind_item_hold": "按住 %s 寻思"
+  "tooltip.ageratum.bind_item_hold": "按住 %s 寻思",
+  "tooltip.ageratum.structure_projection.layer_shortcut": "按下 %s / %s 调整投影层数",
+  "tooltip.ageratum.structure_projection.remove_shortcut": "按下 %s 关闭投影"
 }


### PR DESCRIPTION
- Fixed #23 
- Resolved #20 

本次拉取请求对指南UI、工具提示处理以及水平行布局渲染进行了多项改进。其中最重要的改动包括：增强在指南间导航时UI状态的保持能力，重构工具提示数据结构以更好地支持物品工具提示，以及重新设计水平行布局以支持自动换行而非缩放组件。此外，还对配方和方块渲染逻辑进行了小幅改进和清理。

**指南UI改进：**

*   新增了从侧边栏打开指南时保留当前标签滚动和折叠状态的功能，具体通过引入 `openGuideOnClientPreservingLabelState` 并重构指南打开逻辑，使其可选择继承标签状态来实现。[[1]](diffhunk://#diff-a7f97608b25dd3f414151766120623db78764b4b2391329c55b6d8f3f7321b89R174-R213) [[2]](diffhunk://#diff-a7f97608b25dd3f414151766120623db78764b4b2391329c55b6d8f3f7321b89R224-R226) [[3]](diffhunk://#diff-a7f97608b25dd3f414151766120623db78764b4b2391329c55b6d8f3f7321b89R239-R240) [[4]](diffhunk://#diff-a7f97608b25dd3f414151766120623db78764b4b2391329c55b6d8f3f7321b89L224-R264) [[5]](diffhunk://#diff-a7f97608b25dd3f414151766120623db78764b4b2391329c55b6d8f3f7321b89R284-R285) [[6]](diffhunk://#diff-a7f97608b25dd3f414151766120623db78764b4b2391329c55b6d8f3f7321b89R298-R309)

**工具提示处理改进：**

*   重构了 `MDRenderContext.Tooltip` 记录，使其始终存储关联的 `ItemStack`，从而支持更灵活的工具提示渲染，并更新了工具提示渲染逻辑以使用该信息。[[1]](diffhunk://#diff-1ba17897784e39af6d0df807d78fbb20cb824a7546d6c5bb1a2f75e797749796L65-R84) [[2]](diffhunk://#diff-1ba17897784e39af6d0df807d78fbb20cb824a7546d6c5bb1a2f75e797749796R105-R129)
*   更新了方块和配方物品渲染，将添加“W”键提示的功能委托给集中的工具提示事件处理器，从而简化渲染代码并确保提示注入的一致性。[[1]](diffhunk://#diff-fa689c545937d88268c2e7902f77e9db5203b65b47245a7c0cb7da0a84b45f0cL107-R117) [[2]](diffhunk://#diff-1c47072e71bf0ae8b83925b17b2cfc65eb25dc5e03e317481d790da83d6fbba2L81-R91)

**水平行布局重新设计：**

*   重写了水平行布局（`MDRowComponent`），采用自然尺寸、自动换行的算法，不再缩放组件以适配一行。这改善了当一行内容过多时的可读性和可用性。[[1]](diffhunk://#diff-d6559bac2ace71003ad06879c7ef43b57e2beb463948049d87a4557c6000b4f3L47-L48) [[2]](diffhunk://#diff-d6559bac2ace71003ad06879c7ef43b57e2beb463948049d87a4557c6000b4f3L61) [[3]](diffhunk://#diff-d6559bac2ace71003ad06879c7ef43b57e2beb463948049d87a4557c6000b4f3L108-R144) [[4]](diffhunk://#diff-d6559bac2ace71003ad06879c7ef43b57e2beb463948049d87a4557c6000b4f3L252-R220)

**其他UI/UX改进：**

*   在 `MDNBTStructureComponent` 中，当鼠标悬停在结构按钮上时，为结构投影控制添加了快捷键工具提示。

**构建配置：**

*   将某些 Minecraft 运行任务标记为与 Gradle 配置缓存不兼容，以避免 IntelliJ 调试器出现问题。